### PR TITLE
upgraded dependencies to 0.30.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic
 overrides>=7.3.1,<8.0.0
 openpyxl>=3.0.9,<4.0.0
-py-ai-workflows[docs]>=0.29.0,<1.0.0
+py-ai-workflows[docs]>=0.30.0,<1.0.0
 # dev environment
 jupyter
 ipywidgets

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,12 @@ setup(
     install_requires=[
         'pydantic',
         'overrides>=7.3.1,<8.0.0',
-        'py-ai-workflows>=0.20.0,<1.0.0'
+        'py-ai-workflows>=0.30.0,<1.0.0'
     ],
     extras_require={
         'parser': [
             'openpyxl>=3.0.9,<4.0.0',
-            'py-ai-workflows[docs]>=0.29.0,<1.0.0'
+            'py-ai-workflows[docs]>=0.30.0,<1.0.0'
         ]
     },
     package_data={

--- a/src/surveyeval.egg-info/PKG-INFO
+++ b/src/surveyeval.egg-info/PKG-INFO
@@ -1,4 +1,4 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.4
 Name: surveyeval
 Version: 0.1.28
 Summary: A toolkit for survey evaluation
@@ -11,10 +11,21 @@ Requires-Python: >=3.10
 License-File: LICENSE
 Requires-Dist: pydantic
 Requires-Dist: overrides<8.0.0,>=7.3.1
-Requires-Dist: py-ai-workflows<1.0.0,>=0.20.0
+Requires-Dist: py-ai-workflows<1.0.0,>=0.30.0
 Provides-Extra: parser
 Requires-Dist: openpyxl<4.0.0,>=3.0.9; extra == "parser"
-Requires-Dist: py-ai-workflows[docs]<1.0.0,>=0.29.0; extra == "parser"
+Requires-Dist: py-ai-workflows[docs]<1.0.0,>=0.30.0; extra == "parser"
+Dynamic: author
+Dynamic: author-email
+Dynamic: description
+Dynamic: home-page
+Dynamic: license
+Dynamic: license-file
+Dynamic: project-url
+Dynamic: provides-extra
+Dynamic: requires-dist
+Dynamic: requires-python
+Dynamic: summary
 
 ==========
 surveyeval

--- a/src/surveyeval.egg-info/requires.txt
+++ b/src/surveyeval.egg-info/requires.txt
@@ -1,7 +1,7 @@
 pydantic
 overrides<8.0.0,>=7.3.1
-py-ai-workflows<1.0.0,>=0.20.0
+py-ai-workflows<1.0.0,>=0.30.0
 
 [parser]
 openpyxl<4.0.0,>=3.0.9
-py-ai-workflows[docs]<1.0.0,>=0.29.0
+py-ai-workflows[docs]<1.0.0,>=0.30.0


### PR DESCRIPTION
# Testing Report: py-ai-workflows Upgrade (0.29.0 → 0.30.0)

## Changes
- `requirements.txt`: `py-ai-workflows[docs]>=0.29.0` → `>=0.30.0`
- `setup.py`: Updated main dependency and parser extra to minimum of 0.30.0

## Test Methodology

### Import and Basic Functionality
**Test**: Import all surveyeval modules and instantiate core objects
**Result**: All imports successful, no breaking changes

### Async Method Functionality
**Problem**: Async methods (`a_evaluate()`, `a_run_evaluation_chain()`) were broken in 0.29.0
**Test**: 
- Called `a_evaluate()` on `BiasEvaluationLens` and `PhrasingEvaluationLens`
- Used `asyncio.gather()` for parallel evaluation execution
- Compared functionality between sync and async methods

**Result**: 
- Async methods functional
- Parallel execution working

### Model Type Compatibility
**Test**: Survey parsing and bias evaluation using different OpenAI models
**Models tested**: `gpt-4o-mini`, `gpt-4o`, `o1-mini`, `o1`

**Results**:
- `gpt-4o-mini`: Survey parsing successful, bias evaluation successful, 0 bias issues found
- `gpt-4o`: Survey parsing successful, bias evaluation successful, 0 bias issues found
- `o1`: Survey parsing successful, bias evaluation successful, 0 bias issues found
- `o1-mini`: Failed with API error "Unknown parameter: 'reasoning_effort'"

### API Parameter Investigation
**Test**: Direct OpenAI API calls to isolate `o1-mini` failure
**Method**: Called OpenAI API with and without `reasoning_effort` parameter

**Results**:
- `o1` accepts `reasoning_effort` parameter
- `o1-mini` rejects `reasoning_effort` parameter (400 error)
- `o1-mini` works without `reasoning_effort` parameter
- py-ai-workflows incorrectly applies `reasoning_effort` to all o1-family models

## Technical Details

### Error Analysis
The `o1-mini` failure occurs because py-ai-workflows auto-detects o1-family models and adds `reasoning_effort='low'` parameter, but OpenAI's API only accepts this parameter for `o1` (full model), not `o1-mini`.

## Summary
- Primary bug fix verified: Async methods work in 0.30.0
- `o1-mini` incompatibility is an upstream library limitation