### PR TITLE
Add Dobility acquisition notice to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. note::
+
+   Higher Bar AI is now proudly a part of Dobility, Inc. (the makers of SurveyCTO)! Moving forward, this repository will be actively maintained and supported by the Dobility team.
+
 ==========
 surveyeval
 ==========


### PR DESCRIPTION
## Summary

Adds a banner at the top of the README announcing that Higher Bar AI is now part of Dobility:

> Note: Higher Bar AI is now proudly a part of Dobility, Inc. (the makers of SurveyCTO)! Moving forward, this repository will be actively maintained and supported by the Dobility team.

The banner uses the reStructuredText `.. note::` admonition, which GitHub renders as a highlighted note box (the "Note" label is rendered by the banner itself). This same notice is being added to all 9 repos in the higherbar-ai organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mgc1d5MdBmijN6owtQJzq

---
_Generated by [Claude Code](https://claude.ai/code/session_017mgc1d5MdBmijN6owtQJzq)_